### PR TITLE
Fixes all YAML files in security samples so it shows up in Studio.

### DIFF
--- a/BiometricLoginKotlin/.google/packaging.yaml
+++ b/BiometricLoginKotlin/.google/packaging.yaml
@@ -26,5 +26,5 @@ github:       android/security
 level:        INTERMEDIATE
 apiRefs:
     - android:androidx.biometric.BiometricManager
-    - androidx.biometric.BiometricPrompt
+    - android:androidx.biometric.BiometricPrompt
 license: apache2

--- a/Fido/.google/packaging.yaml
+++ b/Fido/.google/packaging.yaml
@@ -26,12 +26,12 @@ solutions:    [Mobile]
 github:       android/security
 level:        INTERMEDIATE
 apiRefs:
-    - com.google.android.gms.fido.Fido
-    - com.google.android.gms.fido.fido2.Fido2ApiClient
-    - com.google.android.gms.fido.fido2.Fido2PendingIntent
-    - com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
-    - com.google.android.gms.fido.fido2.api.common.AuthenticatorAttestationResponse
-    - com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
-    - com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialCreationOptions
-    - com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialRequestOptions
+    - android:com.google.android.gms.fido.Fido
+    - android:com.google.android.gms.fido.fido2.Fido2ApiClient
+    - android:com.google.android.gms.fido.fido2.Fido2PendingIntent
+    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
+    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorAttestationResponse
+    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
+    - android:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialCreationOptions
+    - android:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialRequestOptions
 license: apache2

--- a/Fido/.google/packaging.yaml
+++ b/Fido/.google/packaging.yaml
@@ -26,12 +26,12 @@ solutions:    [Mobile]
 github:       android/security
 level:        INTERMEDIATE
 apiRefs:
-    - android:com.google.android.gms.fido.Fido
-    - android:com.google.android.gms.fido.fido2.Fido2ApiClient
-    - android:com.google.android.gms.fido.fido2.Fido2PendingIntent
-    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
-    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorAttestationResponse
-    - android:com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
-    - android:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialCreationOptions
-    - android:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialRequestOptions
+    - gms:com.google.android.gms.fido.Fido
+    - gms:com.google.android.gms.fido.fido2.Fido2ApiClient
+    - gms:com.google.android.gms.fido.fido2.Fido2PendingIntent
+    - gms:com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
+    - gms:com.google.android.gms.fido.fido2.api.common.AuthenticatorAttestationResponse
+    - gms:com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
+    - gms:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialCreationOptions
+    - gms:com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialRequestOptions
 license: apache2

--- a/FileLocker/.google/packaging.yaml
+++ b/FileLocker/.google/packaging.yaml
@@ -27,6 +27,6 @@ github:       android/security-samples
 level:        INTERMEDIATE
 icon:         screenshots/notes-list.png
 apiRefs:
-    - androidx.security.crypto.EncryptedFile
-    - androidx.security.crypto.EncryptedSharedPreferences
+    - android:androidx.security.crypto.EncryptedFile
+    - android:androidx.security.crypto.EncryptedSharedPreferences
 license: apache2


### PR DESCRIPTION
Please note, I identified missing 'android:' in the apiRefs. It was not the header markdown, so you can use that in either format (# or =).