### PR TITLE
use the password field entered by the user when logging in

### DIFF
--- a/BiometricLoginKotlin/app/src/main/java/com/example/biometricloginsample/LoginActivity.kt
+++ b/BiometricLoginKotlin/app/src/main/java/com/example/biometricloginsample/LoginActivity.kt
@@ -166,7 +166,7 @@ class LoginActivity : AppCompatActivity() {
         binding.login.setOnClickListener {
             loginWithPasswordViewModel.login(
                 binding.username.text.toString(),
-                binding.login.text.toString()
+                binding.password.text.toString()
             )
         }
         Log.d(TAG, "Username ${SampleAppUser.username}; fake token ${SampleAppUser.fakeToken}")


### PR DESCRIPTION
Fix use the password field entered by the user instead of the text of the login button when logging in