### PR TITLE
update version to avoid error

### DIFF
--- a/FileLocker/build.gradle
+++ b/FileLocker/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         constraint_layout_version = '2.0.4'
         coroutines_version = '1.4.3'
         espresso_version = '3.2.0'
-        gradleVersion = '4.2.1'
+        gradleVersion = '7.4.2'
         junit_version = '4.12'
         kotlin_version = '1.4.32'
         ktx_version = '1.5.0'

--- a/FileLocker/gradle/wrapper/gradle-wrapper.properties
+++ b/FileLocker/gradle/wrapper/gradle-wrapper.properties
@@ -18,7 +18,7 @@
 #Thu Mar 05 17:43:26 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 


### PR DESCRIPTION
When I imported the project and tried to build it as-is, I got an error:
"Unable to make field private final java.lang.String java.io.File.path accessible"

build was successful as soon as I updated the gradle version 